### PR TITLE
Outline dark mode toggle on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,13 +46,12 @@ function App() {
     {
       id: "cabvision", company: 'Cabvision Network Ltd', location: 'London', role: 'Software Engineer', period: 'October 2014 - October 2015, July 2016 - October 2016, September 2018 - June 2019', content: [
         "Payment processing firm. Full stack web & mobile development.",
-        "Web stack:",
-        <span key="web-stack" className="ms-4">PHP (Zend) / jQuery</span>,
-        "Mobile stack:",
-        <span key="polling-client" className="ms-4">Payment polling client / websocket server: Golang</span>,
-        <span key="webhook-server" className="ms-4">Webhook server: Rust</span>,
-        <span key="ios-app" className="ms-4">iOS app: Objective-C and Swift</span>,
-        <span key="android-app" className="ms-4">Android app: Java</span>,
+        "Web stack: PHP (Zend) / jQuery",
+        <span key="mobile-stack" className="">Mobile stack:</span>,
+        <span key="polling-client" className="ps-4">Payment polling client / websocket server: Golang</span>,
+        <span key="webhook-server" className="ps-4">Webhook server: Rust</span>,
+        <span key="ios-app" className="ps-4">iOS app: Objective-C and Swift</span>,
+        <span key="android-app" className="ps-4">Android app: Java</span>,
         "Created native transaction tracking apps (iOS & Android) featuring real-time transaction push notifications, serving thousands of customers. Transactions were web-scraped from the payment processor's portal by the polling client.",
         "Expanded functionality of these apps to support processing of payments using a Payworks mPOS device. The app communicated with a London black cab's meter via a custom serial interface to automatically begin the payment flow upon completion of a fare.",
       ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,7 @@ function App() {
                   style={{
                     animation: 'appear 1ms linear both',
                     animationTimeline: 'view()',
-                    animationRange: 'entry-crossing 20px entry-crossing 200px'
+                    animationRange: 'entry-crossing 20px entry-crossing min(200px, 20vh)'
                   }}>
                   <svg viewBox='0 0 100 100' preserveAspectRatio='none' className="h-full fill-transparent stroke-none">
                     <path className='stroke-light-mode-text dark:stroke-dark-mode-text stroke-[0.5rem]' d='M0 0 V 100' strokeDasharray="5 25" strokeLinecap='square' />
@@ -221,7 +221,7 @@ function WorkItem({ id, company, location, role, period, children }: WorkItemPro
       style={{
         animation: 'appear 1ms linear both',
         animationTimeline: 'view()',
-        animationRange: 'entry-crossing 20px entry-crossing 200px'
+        animationRange: 'entry-crossing 20px entry-crossing min(200px, 20vh)'
       }}>
       <header className="flex flex-col mb-2">
         <h1 className="text-xl font-semibold mb-1">{company}</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ function App() {
               </WorkItem>
 
               {itemIndex !== workItems.length - 1 &&
-                <div key={`work-item-separator-${itemIndex.toString()}`} id={`work-item-separator-${itemIndex.toString()}`} className="w-full h-[4rem] ml-8"
+                <div key={`work-item-separator-${itemIndex.toString()}`} id={`work-item-separator-${itemIndex.toString()}`} className="w-full h-[4rem] pl-8"
                   style={{
                     animation: 'appear 1ms linear both',
                     animationTimeline: 'view()',
@@ -134,7 +134,7 @@ function App() {
         </Accordion>
 
         <Accordion summary="Education">
-          <section className="flex flex-col space-y-2 border border-light-mode-text dark:border-dark-mode-text p-4">
+          <section data-type="timeline-item">
             <header className="flex flex-col mb-2">
               <h1 className="text-xl font-semibold mb-[0.25rem]">University of Cambridge</h1>
               <h3 className="text-xs mb-1">Fitzwilliam College</h3>
@@ -203,12 +203,20 @@ function Accordion({ children, className, summary }: { children: React.ReactNode
     <details
       className={clsx(
         "[&:has(+details)+details]:mt-2 [&[open]:has(+details)+details]:mt-5",
+        "max-sm:!col-span-full max-sm:!mx-0",
         className
       )}
       open
     >
-      <summary className="text-lg cursor-pointer">{summary}</summary>
-      <div className="mt-5">
+      <summary className="text-lg cursor-pointer max-w-full max-sm:pl-6">{summary}</summary>
+      <div className={clsx(
+        "mt-5",
+        "[&>[data-type=timeline-item]]:flex [&>[data-type=timeline-item]]:flex-col",
+        "[&>[data-type=timeline-item]]:space-y-2 [&>[data-type=timeline-item]]:border-y",
+        "[&>[data-type=timeline-item]]:sm:border [&>[data-type=timeline-item]]:p-4",
+        "[&>[data-type=timeline-item]]:border-light-mode-text",
+        "[&>[data-type=timeline-item]]:dark:border-dark-mode-text"
+      )}>
         {children}
       </div>
     </details>
@@ -217,7 +225,8 @@ function Accordion({ children, className, summary }: { children: React.ReactNode
 
 function WorkItem({ id, company, location, role, period, children }: WorkItemProps) {
   return (
-    <section id={`work-item-${id}`} className="flex flex-col space-y-2 border border-light-mode-text dark:border-dark-mode-text p-4"
+    <section id={`work-item-${id}`}
+      data-type="timeline-item"
       style={{
         animation: 'appear 1ms linear both',
         animationTimeline: 'view()',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
         <aside className={clsx(
           "!col-start-1 !col-end-2 row-start-3 row-end-4",
           "text-xs pr-4",
-          "motion-safe:transition-all motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.37,0,0.63,1)]",
+          "motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-[cubic-bezier(0.37,0,0.63,1)]",
           "hidden my-0 h-0 lg:block opacity-0",
           "lg:[&:has(+details[open])]:h-fit lg:[&:has(+details[open])]:mt-[3rem] lg:[&:has(+details[open])]:opacity-100",
         )}>

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import DarkModeIcon from "./DarkModeIcon";
 import LightModeIcon from "./LightModeIcon";
 import clsx from "clsx";
-import { useReducedMotion } from "@react-spring/web";
 
 const getTheme = (): string | null => {
     const theme = window.localStorage.getItem('theme');
@@ -15,29 +14,8 @@ const isDarkModeEnabled = (): boolean => {
 
 export default function DarkModeToggle() {
     const [darkMode, setDarkMode] = useState<boolean>(isDarkModeEnabled());
-    const [isHoveringOverSun, setIsHoveringOverSun] = useState<boolean>(false);
-    const reducedMotion = useReducedMotion();
 
     const containerRef = useRef<HTMLDivElement | null>(null);
-
-    useEffect(() => {
-        if (reducedMotion) {
-            return;
-        }
-
-        const allElements = document.getElementById("root")?.getElementsByTagName("*");
-        for (const element of allElements ?? []) {
-            if (element === containerRef.current || containerRef.current?.contains(element)) {
-                continue;
-            }
-
-            if (darkMode && isHoveringOverSun) {
-                element.classList.add('motion-safe:drop-shadow-sun-shadow', 'transform-gpu');
-            } else {
-                element.classList.remove('motion-safe:drop-shadow-sun-shadow', 'transform-gpu');
-            }
-        }
-    }, [darkMode, isHoveringOverSun, reducedMotion])
 
     useEffect(() => {
         const handleThemeUpdate = () => {
@@ -57,31 +35,38 @@ export default function DarkModeToggle() {
             document.documentElement.classList.remove('dark')
         } else {
             document.documentElement.classList.add('dark');
-            setIsHoveringOverSun(false);
         }
         window.localStorage.setItem('theme', enabled ? 'light' : 'dark');
         window.dispatchEvent(new Event('storage'));
     };
 
     return (
-        <div ref={containerRef} className="fixed top-2 right-3"
-            onMouseEnter={() => { setIsHoveringOverSun(true) }}
-            onMouseLeave={() => { setIsHoveringOverSun(false) }}
+        <div ref={containerRef} className={clsx(
+            "group fixed top-2 right-3",
+            "border rounded-full p-2",
+            "border-light-mode-text dark:border-dark-mode-text",
+            "bg-light-mode-bg dark:bg-dark-mode-bg",
+            "md:p-0 md:border-none md:bg-transparent",
+            "md:hover:p-0 md:active:p-0",
+            "md:hover:top-3 md:active:top-3 md:hover:right-4 md:active:right-4",
+            "md:motion-safe:transition-all md:motion-safe:ease-bounce md:motion-safe:duration-500",
+            "md:motion-safe:[&:hover_~_*_*]:drop-shadow-sun-shadow md:motion-safe:[&:hover_~_*_*]:transform-gpu"
+        )}
         >
-            <div className="group w-full flex justify-end">
+            <div className="w-full flex justify-end">
                 {darkMode && <div className={clsx(
-                    "w-[100vw] h-[100vh] opacity-0 z-[-1] absolute top-[0.75rem] left-[0.75rem]",
+                    "max-sm:hidden w-[100vw] h-[100vh] opacity-0 z-[-1] absolute top-[0.75rem] left-[0.75rem]",
                     "rotate-90 origin-top-left pointer-events-none overflow-visible blur-2xl",
                     "[background:radial-gradient(circle_at_0_0,var(--dark-mode-highlight),transparent_50%)]",
                     "motion-safe:transition-opacity motion-safe:ease-bounce motion-safe:duration-500",
                     "group-hover:opacity-[15%] group-active:opacity-[15%]"
                 )}></div>}
                 <button onClick={handleToggle} aria-label="toggle dark mode" title="toggle dark mode" className={clsx(
-                    "motion-safe:transition-all motion-safe:ease-bounce motion-safe:duration-500",
-                    "group-hover:scale-150 group-active:scale-125",
                     "drop-shadow-bg-light-mode-bg dark:drop-shadow-bg-dark-mode-bg",
-                    "group-hover:drop-shadow-[-1rem_1rem_5px] group-active:drop-shadow-[-1rem_1rem_5px]",
-                    "dark:group-hover:drop-shadow-[0_0_5px] dark:group-active:drop-shadow-[0_0_5px]",
+                    "md:motion-safe:transition-all md:motion-safe:ease-bounce md:motion-safe:duration-500",
+                    "md:group-hover:scale-150 md:group-active:scale-125",
+                    "md:group-hover:drop-shadow-[-1rem_1rem_5px] md:group-active:drop-shadow-[-1rem_1rem_5px]",
+                    "md:dark:group-hover:drop-shadow-[0_0_5px] md:dark:group-active:drop-shadow-[0_0_5px]",
                 )}
                 >
                     {darkMode ? <DarkModeIcon /> : <LightModeIcon />}

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -43,7 +43,7 @@ export default function DarkModeToggle() {
     return (
         <div ref={containerRef} className={clsx(
             "group fixed top-2 right-3",
-            "border rounded-full p-2",
+            "border rounded-full p-2 z-10",
             "border-light-mode-text dark:border-dark-mode-text",
             "bg-light-mode-bg dark:bg-dark-mode-bg",
             "md:p-0 md:border-none md:bg-transparent",
@@ -63,6 +63,7 @@ export default function DarkModeToggle() {
                     "group-hover:opacity-[15%] group-active:opacity-[15%]"
                 )}></div>}
                 <button onClick={handleToggle} aria-label="toggle dark mode" title="toggle dark mode" className={clsx(
+                    "relative",
                     "drop-shadow-bg-light-mode-bg dark:drop-shadow-bg-dark-mode-bg",
                     "md:motion-safe:transition-all md:motion-safe:ease-bounce md:motion-safe:duration-500",
                     "md:group-hover:scale-150 md:group-active:scale-125",
@@ -70,6 +71,7 @@ export default function DarkModeToggle() {
                     "md:dark:group-hover:drop-shadow-[0_0_5px] md:dark:group-active:drop-shadow-[0_0_5px]",
                 )}
                 >
+                    <span className="absolute top-1/2 left-1/2 size-12 rounded-full -translate-x-1/2 -translate-y-1/2"></span>
                     {darkMode ? <DarkModeIcon /> : <LightModeIcon />}
                 </button>
             </div>

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -50,7 +50,8 @@ export default function DarkModeToggle() {
             "md:hover:p-0 md:active:p-0",
             "md:hover:top-3 md:active:top-3 md:hover:right-4 md:active:right-4",
             "md:motion-safe:transition-all md:motion-safe:ease-bounce md:motion-safe:duration-500",
-            "md:motion-safe:[&:hover_~_*_*]:drop-shadow-sun-shadow md:motion-safe:[&:hover_~_*_*]:transform-gpu"
+            "md:motion-safe:[&:hover_~_*]:transform-gpu",
+            "md:motion-safe:[&:hover_~_*]:drop-shadow-sun-shadow dark:md:motion-safe:[&:hover_~_*]:drop-shadow-sun-shadow-dark"
         )}
         >
             <div className="w-full flex justify-end">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,8 @@ export default {
         'bounce': 'cubic-bezier(.47, 1.64, .41, .8)',
       },
       dropShadow: {
-        'sun-shadow': '-3rem 2rem 1px rgba(from var(--dark-mode-highlight) r g b / 0.03)'
+        'sun-shadow': '-3rem 2rem 0.15rem rgba(from var(--light-mode-highlight) r g b / 0.5)',
+        'sun-shadow-dark': '-3rem 2rem 0.15rem rgba(from var(--dark-mode-highlight) r g b / 0.16)'
       },
       keyframes: {
         flash: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,7 @@ export default {
         'bounce': 'cubic-bezier(.47, 1.64, .41, .8)',
       },
       dropShadow: {
-        'sun-shadow': '-3rem 2rem 1px rgba(from var(--dark-mode-highlight) r g b / 0.01)'
+        'sun-shadow': '-3rem 2rem 1px rgba(from var(--dark-mode-highlight) r g b / 0.03)'
       },
       keyframes: {
         flash: {


### PR DESCRIPTION
Also:
- timeline is full bleed on mobile screens to allow more space for text
- shadow cast by dark mode toggle hover is now pure CSS (no JS event handling)
- opacity reveal animation range now uses `min(200px, 20vh)` for the end, to ensure items are fully opaque on short, low dpi screens
- fix "mobile stack" items left indent